### PR TITLE
Standardize all output in JSON format

### DIFF
--- a/Firmware/radio/loop.c
+++ b/Firmware/radio/loop.c
@@ -144,7 +144,7 @@ static void one_second(void)
 			radio_receiver_on();
 			one_second_counter = 0;
 		}
-		printf("Searching %lu at %lu Hz\n", 
+		printf("{\"ready\": false, \"status\": \"Searching %lu at %lu Hz\"}\n", 
 		       (unsigned long)seconds_since_boot,
 		       (unsigned long)fhop_receive_freqency());
 		return;
@@ -191,7 +191,7 @@ static void print_hex(register uint8_t v)
 static void show_iss_data(void)
 {
 	__pdata uint8_t i;
-	printf("{ ");
+	printf("{ \"ready\": true, \"status\": \"Receiving ISS data\", ");
 	if (iss_data.valid_mask & VALID_TRANSMITTER) {
 		printf("\"transmitter_id\": %u, ", (unsigned)iss_data.transmitter_id);
 	}


### PR DESCRIPTION
This patch formats the "Searching..." messages that appear before the ISS is synced as JSON.  This makes it easier to parse the output of the device when it's first connected.

BTW, thanks so much for DavisSi1000.  I stumbled upon this while investigating using a SDR to read the ISS broadcasts but struggled to understand GFSK demodulation.   Bravo for finding the Si1000 and making this work.  This is every bit as amazing as Samba was to me in 1993.  :-)

For what it's worth, I'm using this successfully with a cheap (Chinese?) clone of the 3DR USB stick [from eBay.](http://www.ebay.com/sch/i.html?_odkw=3dr+hobby-pro&_osacat=0&_from=R40&_trksid=p2045573.m570.l1313.TR2.TRC0.A0.H0.X3dr+usb.TRS0&_nkw=3dr+usb&_sacat=0)
