### PR TITLE
Use latest pexpect style

### DIFF
--- a/Firmware/tools/update_mode.py
+++ b/Firmware/tools/update_mode.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 # put a HopeRF into update mode
 
-import serial, sys, optparse, time, fdpexpect
+import serial, sys, optparse, time, pexpect
+from pexpect import fdpexpect
 
 parser = optparse.OptionParser("update_mode")
 parser.add_option("--baudrate", type='int', default=57600, help='baud rate')

--- a/Firmware/tools/uploader.py
+++ b/Firmware/tools/uploader.py
@@ -194,7 +194,8 @@ class uploader(object):
 
 	def autosync(self):
 		'''use AT&UPDATE to put modem in update mode'''
-		import fdpexpect, time
+		import pexpect, time
+		from pexpect import fdpexpect
 		ser = fdpexpect.fdspawn(self.port.fileno(), logfile=sys.stdout)
 		if self.atbaudrate != 115200:
 			self.port.setBaudrate(self.atbaudrate)
@@ -204,7 +205,7 @@ class uploader(object):
 		ser.send('+++')
 		try:
 			ser.expect('OK', timeout=1.1)
-		except fdpexpect.TIMEOUT:
+		except pexpect.TIMEOUT:
 			# may already be in AT mode
 			pass
 		for i in range(5):


### PR DESCRIPTION
The pexpect module has changed since the updaters were written.

On a side note, `console.py` is still broken--it seems that pexpect might not have an interact() method for fdpexpect.  Not totally sure here but I banged around on it with no success.
